### PR TITLE
feat: add /assign bot

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -1,0 +1,25 @@
+# This file is regarding the /assign bot
+name: Assign
+
+on:
+  schedule:
+    - cron: '*/59 * * * *'
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash_assign:
+    # If the acton was triggered by a new comment that starts with `/assign`
+    # or a on a schedule
+    if: >
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/assign')) ||
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: JasonEtco/slash-assign-action@v0.0.3
+        with:
+          assigned_label: Assigned
+          days_until_warning: 7
+          days_until_unassign: 14
+          stale_assignment_label: Open


### PR DESCRIPTION
## Related Issues or Pull Requests

https://github.com/DSC-SIST/Discord-Bot/issues/27

### Have you read the [Contributing Guidelines on Pull Requests]

Yes.

### Description

Added the feature to let the contributor assign themselves to an issue by just commenting `/assgin`

### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.
- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Fill in the appropriate details -->
#### File(s) Added / Modified

- `assign.yaml`

<!-- Fill in the appropriate details -->
#### Language(s) Used

- YAML
